### PR TITLE
Fix broken links

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,5 +10,5 @@ src = "src"
 title = "ROAR-NET API Specification"
 
 [output.html]
-edit-url-template="https://github.com/roar-net/roar-net-api-specification/edit/main/{path}"
+edit-url-template="https://github.com/roar-net/roar-net-api-spec/edit/main/{path}"
 mathjax-support = true

--- a/src/README.md
+++ b/src/README.md
@@ -72,7 +72,7 @@ Furthermore, it considers the following main algorithmic approaches:
 
 Extensions to multiple objectives, uncertainty settings, and support for
 further algorithms are currently under discussion on the [Github
-repository](https://github.com/roar-net/roar-net-api-specification),
+repository](https://github.com/roar-net/roar-net-api-spec),
 where everyone is welcome to contribute and propose new ideas.
 
 ## Acknowledgement


### PR DESCRIPTION
Fixed two incorrect links: [https://github.com/roar-net/roar-net-api-specification](https://github.com/roar-net/roar-net-api-specification) -> [https://github.com/roar-net/roar-net-api-spec](https://github.com/roar-net/roar-net-api-spec).